### PR TITLE
upgrade react-tools to 0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     },
     "homepage": "https://github.com/fouber/fis-parser-react",
     "dependencies" : {
-        "react-tools" : "0.9.0"
+        "react-tools" : "~0.12.2"
     }
 }


### PR DESCRIPTION
 @fouber  最近在研究react, 发现这个插件无法编译0.12.1版本的jsx代码. 所以将依赖的react-tools升级到0.12.2, 请将它提交到npm中. thanks
